### PR TITLE
desktop themes dont auto update when 2 settings windows are open

### DIFF
--- a/web/ts/settings.ts
+++ b/web/ts/settings.ts
@@ -1,5 +1,15 @@
 const channel = new BroadcastChannel("seekr-channel");
 
+channel.addEventListener('message', (event) => {
+  if (event.data.type === "theme") {
+    const theme = event.data.theme;
+
+    document.documentElement.setAttribute("data-theme", theme);
+  } else if (event.data.type === "language") {
+    translate()
+  }
+});
+
 const themeCardContainer = document.querySelector(".theme-option") as HTMLDivElement;
 
 function changeTheme(theme: string): void {


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Project infrastructure change (like issue templates, etc.)

# How Has This Been Tested?

Please check all browsers you have tested on. Please also list any relevant details for your test configuration


- [x] Chromium Based Browser
- [ ] Mozilla Firefox

**Test Configuration**:
- [x] Windows
- [ ] Linux
- [ ] MacOS
- [ ] BSD

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I am a web developer