### PR TITLE
Fix desktop shortcut menu toggle

### DIFF
--- a/web/ts/desktop.ts
+++ b/web/ts/desktop.ts
@@ -118,11 +118,29 @@ function createSeekrSettingsWindow() {
 //   appIcon.src = "./img/seekr-icon.png";
 // });
 
-const shortcutMenu = document.querySelector('.shortcut-menu');
-const appBar = document.querySelector('.app-bar');
-shortcutMenu!.addEventListener('click', function() {
-  appBar!.classList.toggle('clicked');
-});
+function setupShortcutMenu() {
+  const shortcutMenu = document.querySelector('.shortcut-menu') as HTMLElement | null;
+  const appBar = document.querySelector('.app-bar') as HTMLElement | null;
+
+  if (!shortcutMenu || !appBar) {
+    console.error("SEEKR Desktop: shortcut-menu or app-bar not found");
+    return;
+  }
+
+  shortcutMenu.addEventListener("click", function (event) {
+    event.preventDefault();
+    event.stopPropagation();
+    event.stopImmediatePropagation();
+
+    appBar.classList.toggle("clicked");
+  }, true);
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", setupShortcutMenu);
+} else {
+  setupShortcutMenu();
+}
 
 
 // Replace the hex color code with the desired one


### PR DESCRIPTION
# Description

This PR fixes an issue in the SEEKR Desktop interface where clicking the shortcut menu button did not open the app bar.

The click handler for `.shortcut-menu` has been updated to initialize safely after the DOM is ready, verify that both `.shortcut-menu` and `.app-bar` exist, and prevent duplicate event propagation before toggling the `clicked` class on the app bar.

This makes the desktop app launcher open and close correctly when clicking the shortcut menu button.

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update
* [ ] Project infrastructure change (like issue templates, etc.)

# How Has This Been Tested?

Tested locally by running:

* `go generate ./...`
* `tsc -p web/tsconfig.json`
* `go run main.go`

Then opened:

* `http://localhost:8569/web/desktop.html`

Confirmed that clicking the shortcut menu button correctly opens and closes the desktop app bar.

* [ ] Chromium Based Browser
* [x] Mozilla Firefox

**Test Configuration**:

* [ ] Windows
* [x] Linux
* [ ] MacOS
* [ ] BSD

# Checklist:

* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] My changes generate no new warnings
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [x] I am a web developer
